### PR TITLE
Add VsCode settings to exclude Zephyr workspace

### DIFF
--- a/docs/lesson-running-on-small-platforms.md
+++ b/docs/lesson-running-on-small-platforms.md
@@ -4,6 +4,24 @@ In this exercise, you'll cross-compile your F´ deployment to run on a **Raspber
 
 The goal is to create an F´ deployment and get it running on constrained hardware, which includes understanding the integration and configuration steps required for embedded targets, and optimizing the deployment and configuration to fit the constraints of the target hardware.
 
+> [!CAUTION]
+> Zephyr, Zephyr Modules, F Prime, and F Prime libraries consist of a large number of files. This can overwhelm the Raspberry PI 5 provided for the class when running in an indexing IDE. Excluding file watching and C++ intellisense on Zephyr files can offer a speed improvement.
+> 
+> **Excluding Zephyr Workspace From Build (VsCode)**
+>
+> Add the following to the VsCode `setting.json` file:
+> 
+> ```json
+> {
+>     "files.watcherExclude": {
+>         "**/zephyr-workspace/**": true,
+>     },
+>     "C_Cpp.files.exclude": {
+>         "**/zephyr-workspace/**": true,
+>     }
+> }
+> ```
+
 ---
 
 ## Learning Points
@@ -45,6 +63,8 @@ You should do the following:
 * **Compilation troubleshooting**: Some components are platform-specific. `fprime-bootstrap` uses the Linux implementations by default. Attempting to compile Linux-specific code for Zephyr will result in errors, so those components will need to be switched to their Zephyr equivalents.
 * **Consider Your Components**: `fprime-bootstrap` and `fprime-util new --deployment` ship with a fairly broad number of standard F Prime components. Which do you actually need to prove F Prime on the Pico 2?
 * **Tailoring the Project configuration**: The entire system can be further configured to optimize for your constraints, by updating the project configuration. Areas to look at include: subtopology configurations (`fprime/Svc/Subtopologies/`), project configuration (`fprime/default/config/`)
+> [!TIP]
+> This is done by creating a project configuration module (typically `<project>/project/config`) where configuration overrides are kept.
 * **Tailoring the Deployment**: The "stock" F´ deployment likely has too large of a memory footprint to run on a Raspberry Pi Pico 2. `TlmChan` and `CmdDispatcher` are two components known to have a large memory footprint. Identify whether they can be swapped OR configured to fit in your constraints. Some subtopologies may also not be required for a minimal working deployment.
 * **Cross Compile With Zephyr**: use the optional positional argument to `fprime-util` to cross compile with Zephyr
 ```


### PR DESCRIPTION
Added instructions for excluding Zephyr workspace from build in VsCode to improve performance on Raspberry Pi 5.